### PR TITLE
fixing wrong commit: 41bc2ea >> viewProcessors did not work

### DIFF
--- a/src/robotlegs/bender/extensions/viewProcessorMap/impl/ViewProcessorFactory.hx
+++ b/src/robotlegs/bender/extensions/viewProcessorMap/impl/ViewProcessorFactory.hx
@@ -125,7 +125,7 @@ class ViewProcessorFactory implements IViewProcessorFactory
 
 	private function createProcessor(processorClass:Class<Dynamic>):Dynamic
 	{
-		if (_injector.hasMapping(processorClass))
+		if (_injector.hasMapping(processorClass) == false)
 		{
 			_injector.map(processorClass).asSingleton();
 		}


### PR DESCRIPTION
Due to a missing "!" while converting the files to Haxe, the ViewProcessors didn't work properly.