### PR TITLE
Added constructor to create and use directly LocalEventMap

### DIFF
--- a/src/robotlegs/bender/extensions/localEventMap/impl/EventMap.hx
+++ b/src/robotlegs/bender/extensions/localEventMap/impl/EventMap.hx
@@ -191,4 +191,8 @@ class EventMap implements IEventMap
 			listener(event);
 		}
 	}
+
+	public function new() {
+		
+    }
 }


### PR DESCRIPTION
Since the local event map can be used as a local object managing event mappings. It makes sense to be able to directly create an instance of it. 