### PR TITLE
fix EventDispatcher for latest OpenFL version

### DIFF
--- a/src/openfl/events/EventDispatcher.hx
+++ b/src/openfl/events/EventDispatcher.hx
@@ -188,7 +188,7 @@ class EventDispatcher implements IEventDispatcher {
 	
 	private function __dispatchEvent (event:Event):Bool {
 		
-		if (__eventMap == null || event == null) return false;
+		if (__eventMap == null || event == null) return true;
 		
 		var type = event.type;
 		var list;
@@ -213,7 +213,7 @@ class EventDispatcher implements IEventDispatcher {
 		} else {
 			
 			list = __eventMap.get (type);
-			if (list == null) return false;
+			if (list == null) return true;
 			
 		}
 		__dispatchingCount.set (type, wasDispatchingCount + 1);


### PR DESCRIPTION
Not sure why... but tested and compared to openfl EventDispatcher, it needs to return `true` to work correctly...