### PR TITLE
Improvements to Stack / Layer Initializers

### DIFF
--- a/src/robotlegs/bender/extensions/display/base/api/ILayerInitializer.hx
+++ b/src/robotlegs/bender/extensions/display/base/api/ILayerInitializer.hx
@@ -1,0 +1,10 @@
+package robotlegs.bender.extensions.display.base.api;
+
+/**
+ * @author Thomas Byrne
+ */
+interface ILayerInitializer 
+{
+	function checkLayerType(ViewClass:Class<Dynamic>):Bool;
+	function addLayer(ViewClass:Class<Dynamic>, index:Int, total:Int, id:String):Void;
+}

--- a/src/robotlegs/bender/extensions/display/base/impl/BaseInitializer.hx
+++ b/src/robotlegs/bender/extensions/display/base/impl/BaseInitializer.hx
@@ -2,6 +2,7 @@ package robotlegs.bender.extensions.display.base.impl;
 
 import org.swiftsuspenders.utils.DescribedType;
 import robotlegs.bender.extensions.contextView.ContextView;
+import robotlegs.bender.extensions.display.base.api.ILayerInitializer;
 import robotlegs.bender.extensions.display.base.api.ILayers;
 import robotlegs.bender.extensions.display.base.api.IRenderContext;
 import robotlegs.bender.extensions.display.base.api.IRenderer;
@@ -10,13 +11,14 @@ import robotlegs.bender.framework.api.IContext;
  * ...
  * @author P.J.Shand
  */
-class BaseInitializer implements DescribedType
+class BaseInitializer implements DescribedType implements ILayerInitializer
 {
 	@inject public var renderer:IRenderer;
 	@inject public var renderContext:IRenderContext;
 	@inject public var contextView:ContextView;
 	@inject public var context:IContext;
 	@inject public var layers:ILayers;
+	
 	private var _debug:Bool = false;
 	public var debug(get, set):Bool;
 	
@@ -25,9 +27,14 @@ class BaseInitializer implements DescribedType
 		
 	}
 	
-	public function addLayer(ViewClass:Class<Dynamic>, index:Int, id:String):Void 
+	public function checkLayerType(ViewClass:Class<Dynamic>):Bool 
 	{
-		
+		throw "Must override";
+	}
+	
+	public function addLayer(ViewClass:Class<Dynamic>, index:Int, total:Int, id:String):Void 
+	{
+		throw "Must override";
 	}
 	
 	private function autoID(ClassName:Class<Dynamic>):String 
@@ -49,5 +56,17 @@ class BaseInitializer implements DescribedType
 	public function get_debug():Bool 
 	{
 		return _debug;
+	}
+	
+	
+	
+	function CheckClass(layerClass:Class<Dynamic>, _Class:Class<Dynamic>):Bool
+	{
+		if (layerClass == _Class) return true;
+		else {
+			var superClass:Class<Dynamic> = Type.getSuperClass(layerClass);
+			if (superClass == null) return false;
+			else return CheckClass(superClass, _Class);
+		}
 	}
 }

--- a/src/robotlegs/bender/extensions/display/stage3D/away3d/impl/Away3DInitializer.hx
+++ b/src/robotlegs/bender/extensions/display/stage3D/away3d/impl/Away3DInitializer.hx
@@ -16,7 +16,12 @@ class Away3DInitializer extends BaseInitializer
 		
 	}
 	
-	override public function addLayer(ViewClass:Class<Dynamic>, index:Int, id:String):Void
+	override public function checkLayerType(ViewClass:Class<Dynamic>):Bool 
+	{
+		return CheckClass(ViewClass, AwayLayer) || CheckClass(ViewClass, AwayStereoLayer);
+	}
+	
+	override public function addLayer(ViewClass:Class<Dynamic>, index:Int, total:Int, id:String):Void
 	{
 		var stage3DRenderContext:Stage3DRenderContext = cast renderContext;
 		if (id == "") id = autoID(ViewClass);

--- a/src/robotlegs/bender/extensions/display/stage3D/fuse/impl/FuseInitializer.hx
+++ b/src/robotlegs/bender/extensions/display/stage3D/fuse/impl/FuseInitializer.hx
@@ -23,7 +23,12 @@ class FuseInitializer extends BaseInitializer
 		
 	}
 	
-	override public function addLayer(ViewClass:Class<Dynamic>, index:Int, id:String):Void 
+	override public function checkLayerType(ViewClass:Class<Dynamic>):Bool 
+	{
+		return CheckClass(ViewClass, FuseLayer);
+	}
+	
+	override public function addLayer(ViewClass:Class<Dynamic>, index:Int, total:Int, id:String):Void 
 	{
 		var fuseConfig:FuseConfig = { frameRate:60 };
 		fuseConfig.useCacheLayers = true;

--- a/src/robotlegs/bender/extensions/display/stage3D/starling/impl/StarlingInitializer.hx
+++ b/src/robotlegs/bender/extensions/display/stage3D/starling/impl/StarlingInitializer.hx
@@ -27,7 +27,12 @@ class StarlingInitializer extends BaseInitializer
 		}
 	}
 	
-	override public function addLayer(ViewClass:Class<Dynamic>, index:Int, id:String):Void 
+	override public function checkLayerType(ViewClass:Class<Dynamic>):Bool 
+	{
+		return CheckClass(ViewClass, StarlingLayer);
+	}
+	
+	override public function addLayer(ViewClass:Class<Dynamic>, index:Int, total:Int, id:String):Void 
 	{
 		var stage3DRenderContext:Stage3DRenderContext = cast renderContext;
 		//var viewRectangle:Rectangle = new Rectangle(0,0, Viewport.width, Viewport.height);
@@ -58,7 +63,7 @@ class StarlingInitializer extends BaseInitializer
 		#end
 		starling.simulateMultitouch = true;
 		//starling.enableErrorChecking = Capabilities.isDebugger;
-		starling.shareContext = true;
+		starling.shareContext = total > 1;
 		starling.start();
 		
 		#if !starling_1_x

--- a/src/robotlegs/bender/extensions/display/webGL/threejs/impl/ThreeJsInitializer.hx
+++ b/src/robotlegs/bender/extensions/display/webGL/threejs/impl/ThreeJsInitializer.hx
@@ -14,7 +14,12 @@ class ThreeJsInitializer extends BaseInitializer
 		
 	}
 	
-	override public function addLayer(ViewClass:Class<Dynamic>, index:Int, id:String):Void
+	override public function checkLayerType(ViewClass:Class<Dynamic>):Bool 
+	{
+		return CheckClass(ViewClass, ThreeJsLayer);
+	}
+	
+	override public function addLayer(ViewClass:Class<Dynamic>, index:Int, total:Int, id:String):Void
 	{
 		if (id == "") id = autoID(ViewClass);
 		var threeJsLayer:ThreeJsLayer = Type.createInstance(ViewClass, []);


### PR DESCRIPTION
Hey Pete/others,
I was looking into disabling Starling.shareContext when it isn't required and thought I'd make some tweaks to the Layer initialization stuff. Functionally it doesn't change much, just a little cleaner / simpler.

- Created 'ILayerInitializer' interface to loosen Stack's requirements
- Added ILayerInitializer.checkLayerType() to make Stack more agnostic
- Added Stack.addInitializer to allow adding arbitrary display engines
- Delayed Layer initialization by 1ms to allow total layer count to be calculated
- StarlingInitializer only sets shareContext to true when totalLayers > 1

Obviously if you add more layers after startup then the original layer count won't match the real amount of layers, but I figure this is a bit of an edge case. All this variable does at the moment is enable shareContext on Starling Layers, so I guess in this situation you'd have to manually set shareContext=true.